### PR TITLE
Remove un-attainable requirement

### DIFF
--- a/assignments/a1.md
+++ b/assignments/a1.md
@@ -58,8 +58,6 @@ This repository (for CSC491) will be setup like this, but may evolve over time.
 
 You must [create a release](https://help.github.com/en/articles/creating-releases) on your repo.
 This will give us a snapshot in time and allow us to grade it.
-
-The body of the release must include a list of Pull Requests (at least one from every member) that has reviews.
  
  # Questions or Concerns?
  


### PR DESCRIPTION
This requirement had assumed there would be enough 491 students to make this possible. I was hoping we could use https://help.github.com/en/articles/about-pull-request-reviews

As we have, on average, 1 491 student per team it makes sense to just remove that requirement. If you have PRs and got reviews from 454 students or your second 491 student, then that's great. I'd love to see that called out. It means you're learning and using Github like a real startup already 😸 

cc @dcsil/csc491-f19 