### PR TITLE
Add Indie Hackers Podcast to resources

### DIFF
--- a/other_pages/resources_readings.md
+++ b/other_pages/resources_readings.md
@@ -15,3 +15,4 @@ I encourage you to make a PR to add materials you think are useful here too!
 | -- | -- | -- | -- | -- |
 | Shape Up |  Ryan Singer (Basecamp) | Product | https://basecamp.com/shapeup | Free |
 | The Lean Startup | Eric Ries | Product | http://theleanstartup.com/ | $15 - 30 |
+| The Indie Hackers Podcast | Courtland Allen | Product | https://www.indiehackers.com/podcast or wherever you normally listen to podcasts | Free |


### PR DESCRIPTION
The Indie Hackers Podcast is a a great resource where entrepreneurs of all kinds candidly share their story, their revenue numbers, and the nitty gritty details of how they did what they did. It really shows the diversity in the kinds of businesses and entrepreneurs that have become successful, including entrepreneurs that raise no funding and instead sell their products from day one.