### PR TITLE
Cancel final demo, extend deadline for A6

### DIFF
--- a/assignments/README.md
+++ b/assignments/README.md
@@ -10,8 +10,7 @@ There are a number of assignments that make up your final grade, the weights are
 | [Assignment 3](./a3.md) | Tech Choices, Architecture Diagram, Roadmap | 20% | Repo |
 | [Assignment 4](./a4.md) | Dev Env, Test Infrastructure, & Production Setup | 20% | Repo |
 | [Assignment 5](./a5.md) | UX Research w/Prototype, Roadmap Updates | 10% | Repo |
-| [Assignment 6](./a6.md) | Software | 20% | Repos |
-| [Final Demo](./final_demo.md) | Final Demo of your Prototype | 10% | In-class presentation |
+| [Assignment 6](./a6.md) | Software | 30% | Repos |
 | [Bonus](./bonus.md) | Bonus Assignment(s) | up to +5% | Varies |
 | | **Total** | 100% (+5%) | |
 

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -14,8 +14,9 @@
 | N/A | Thursday, March 12 2020 | Online (Zoom) | Security Talk & Workshop from Guest Speaker |
 | 10 | Thursday, March 19 2020 | Online (Zoom) | UX & UI (TBD?), Work in Class |
 | 11 | Thursday, March 26 2020 | Online (Zoom) | Lecture TBD / Work in Class |
-| 12 | Thursday, April 2 2020 | Online (Zoom) | ❗Final Demos and A6 - Software Due (Last Class) |
+| 12 | Thursday, April 2 2020 | Online (Zoom) | Informal Demos of your Software |
 | N/A | Friday, April 3 2020 | N/A | Bonus Assignment Due |
+| N/A | Thursday, April 9 2020 | N/A | ❗A6 Due - Software Due (Last Class) |
 
 `**` The TA will manage this class while the lecturer is away
 ❗denotes an assignment or demo is due

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -16,7 +16,7 @@
 | 11 | Thursday, March 26 2020 | Online (Zoom) | Lecture TBD / Work in Class |
 | 12 | Thursday, April 2 2020 | Online (Zoom) | Informal Demos of your Software |
 | N/A | Friday, April 3 2020 | N/A | Bonus Assignment Due |
-| N/A | Thursday, April 9 2020 | N/A | ❗A6 Due - Software Due (Last Class) |
+| N/A | Monday, April 20 2020 | N/A | ❗A6 Due - Software Due (Last Class) |
 
 `**` The TA will manage this class while the lecturer is away
 ❗denotes an assignment or demo is due


### PR DESCRIPTION
What this does
---
- This cancels the final demo, and replaces it with an informal live-demo of whatever you have on April 2.
- This extends the deadline for A6 by one week (April 2 -> April 20 deadline)
- This increases the A6 worth by 10% (20% -> 30%) to account for the cancelled final demo.

Why?
---
In light of the recent state of the world, there is enough anxiety, stress, and uncertainty. To add to all of that, our friends from the National University of Singapore have been recalled home. To accommodate the change in your team structure, this change aims to reduce the amount of work you have to complete.

I recognize that the increase of the percent in A6 may seem detrimental to some, and I am open to discussions around this.

To Merge
---
This is a change to the syllabus and requires a majority vote. Please [approve this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/approving-a-pull-request-with-required-reviews) if you would like this change to be made official, or request changes in the same flow if you wish to tweak the proposed change (or reject it).

We will finalize the vote during Thursday's class 😄  

In place