### PR TITLE
Move Demo 3, update content

### DIFF
--- a/assignments/a6.md
+++ b/assignments/a6.md
@@ -9,8 +9,8 @@ The demos should be (roughly) on these topics:
 
 - Demo 1: Decisions and Tech Stack, at minimum a Hello World application in your chosen language/platform. Explain why you chose your techs, similar to the StackShare.io requirements in A3. How does this all support your product?
 - Demo 2: Show your application running on CI, which means some basic tests (at minimum). Show us your test harness, what library did you choose, what troubles did you have?
-- Demo 3: Minimal front end, mobile, and back end (as applicable). Starting code for any data models. Some functionality
-- Demo 4: Full software, general functionality, note any shortcomings or areas to improve. Identify all main use cases implemented. Identify use cases to be completed.
+- Demo 3: You will describe a particularly tough technical problem you are working on, the troubles you've faced, and how you solved/are solving them.
+- Demo 4: [1:1 with teaching staff] Full software, general functionality, note any shortcomings or areas to improve. Identify all main use cases implemented. Identify use cases to be completed.
 
 Demos _do not_ need to be a high quality production. You can record your screen for a minute or 2, you can do it live, you can show us screen shots and discuss those... whatever you like. All we ask is that you show us progress.
 

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -11,11 +11,11 @@ This is a class schedule indicating what we aim to do each week and the recommen
 | 4 | Thursday, February 4 2021  | -   | Guest Speaker | Different Kinds of Tests / Best Practices - Languages / Best Pracitces - Linting, Semantic Analysis, etc |
 | 5 | Thursday, February 11 2021  | ❗A3 Due<br>❗A6 Demo | Work in Class | UX Reasearch + Data Bias |
 | 6 | Thursday, February 18 2021 | -          | NO CLASS - Reading Week | - | 
-| 7 | Thursday, February 25 2021 | ❗A4 Due | Work in Class | Infrastructure, Prod Eng, Production, etc |
+| 7 | Thursday, February 25 2021 | ❗A4 Due | Work in Class<br>❗A6 Demos | Infrastructure, Prod Eng, Production, etc |
 | 8 | Thursday, March 4 2021 | -  | Discussions around Infrastructure | Ethics and Accessibility | 
-| 9 | Thursday, March 11 2021     | ❗A5 Due<br>❗A6 Demo  | Guest Speaker | - | 
+| 9 | Thursday, March 11 2021     | ❗A5 Due<br>❗A6 Demo | Guest Speaker | - | 
 | 10 | Thursday, March 18 2021  | - | Work in Class | - | 
-| 11 | Thursday, March 25 2021   | -           | Work in Class<br>❗A6 Demos | - | 
+| 11 | Thursday, March 25 2021   | -           | Work in Class| - | 
 | 12 | Thursday, April 1 2021    | - | Work in Class | - | 
 | 13 | Thursday, April 8 2021    | ❗A7 Due<br>❗A6 Demo | Software Due - Demos of your Software | - | 
 | N/A | Friday, April 9 2021  | -           | Bonus Assignment Due | - | 

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -11,7 +11,7 @@ This is a class schedule indicating what we aim to do each week and the recommen
 | 4 | Thursday, February 4 2021  | -   | Guest Speaker | Different Kinds of Tests / Best Practices - Languages / Best Pracitces - Linting, Semantic Analysis, etc |
 | 5 | Thursday, February 11 2021  | ❗A3 Due<br>❗A6 Demo | Work in Class | UX Reasearch + Data Bias |
 | 6 | Thursday, February 18 2021 | -          | NO CLASS - Reading Week | - | 
-| 7 | Thursday, February 25 2021 | ❗A4 Due | Work in Class<br>❗A6 Demos | Infrastructure, Prod Eng, Production, etc |
+| 7 | Thursday, February 25 2021 | ❗A4 Due<br>❗A6 Demo | Work in Class | Infrastructure, Prod Eng, Production, etc |
 | 8 | Thursday, March 4 2021 | -  | Discussions around Infrastructure | Ethics and Accessibility | 
 | 9 | Thursday, March 11 2021     | ❗A5 Due<br>❗A6 Demo | Guest Speaker | - | 
 | 10 | Thursday, March 18 2021  | - | Work in Class | - | 

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -13,9 +13,9 @@ This is a class schedule indicating what we aim to do each week and the recommen
 | 6 | Thursday, February 18 2021 | -          | NO CLASS - Reading Week | - | 
 | 7 | Thursday, February 25 2021 | ❗A4 Due<br>❗A6 Demo | Work in Class | Infrastructure, Prod Eng, Production, etc |
 | 8 | Thursday, March 4 2021 | -  | Discussions around Infrastructure | Ethics and Accessibility | 
-| 9 | Thursday, March 11 2021     | ❗A5 Due<br>❗A6 Demo | Guest Speaker | - | 
+| 9 | Thursday, March 11 2021     | ❗A5 Due | Guest Speaker | - | 
 | 10 | Thursday, March 18 2021  | - | Work in Class | - | 
-| 11 | Thursday, March 25 2021   | -           | Work in Class| - | 
+| 11 | Thursday, March 25 2021   | - ❗A6 Demo  | Work in Class| - | 
 | 12 | Thursday, April 1 2021    | - | Work in Class | - | 
 | 13 | Thursday, April 8 2021    | ❗A7 Due<br>❗A6 Demo | Software Due - Demos of your Software | - | 
 | N/A | Friday, April 9 2021  | -           | Bonus Assignment Due | - | 

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -15,7 +15,7 @@ This is a class schedule indicating what we aim to do each week and the recommen
 | 8 | Thursday, March 4 2021 | -  | Discussions around Infrastructure | Ethics and Accessibility | 
 | 9 | Thursday, March 11 2021     | ❗A5 Due<br>❗A6 Demo  | Guest Speaker | - | 
 | 10 | Thursday, March 18 2021  | - | Work in Class | - | 
-| 11 | Thursday, March 25 2021   | -           | Work in Clas<br>❗A6 Demos | - | 
+| 11 | Thursday, March 25 2021   | -           | Work in Class<br>❗A6 Demos | - | 
 | 12 | Thursday, April 1 2021    | - | Work in Class | - | 
 | 13 | Thursday, April 8 2021    | ❗A7 Due<br>❗A6 Demo | Software Due - Demos of your Software | - | 
 | N/A | Friday, April 9 2021  | -           | Bonus Assignment Due | - | 

--- a/other_pages/schedule.md
+++ b/other_pages/schedule.md
@@ -11,11 +11,11 @@ This is a class schedule indicating what we aim to do each week and the recommen
 | 4 | Thursday, February 4 2021  | -   | Guest Speaker | Different Kinds of Tests / Best Practices - Languages / Best Pracitces - Linting, Semantic Analysis, etc |
 | 5 | Thursday, February 11 2021  | ❗A3 Due<br>❗A6 Demo | Work in Class | UX Reasearch + Data Bias |
 | 6 | Thursday, February 18 2021 | -          | NO CLASS - Reading Week | - | 
-| 7 | Thursday, February 25 2021 | ❗A4 Due<br>❗A6 Demo  | Work in Class | Infrastructure, Prod Eng, Production, etc |
+| 7 | Thursday, February 25 2021 | ❗A4 Due | Work in Class | Infrastructure, Prod Eng, Production, etc |
 | 8 | Thursday, March 4 2021 | -  | Discussions around Infrastructure | Ethics and Accessibility | 
 | 9 | Thursday, March 11 2021     | ❗A5 Due<br>❗A6 Demo  | Guest Speaker | - | 
 | 10 | Thursday, March 18 2021  | - | Work in Class | - | 
-| 11 | Thursday, March 25 2021   | -           | Work in Class | - | 
+| 11 | Thursday, March 25 2021   | -           | Work in Clas<br>❗A6 Demos | - | 
 | 12 | Thursday, April 1 2021    | - | Work in Class | - | 
 | 13 | Thursday, April 8 2021    | ❗A7 Due<br>❗A6 Demo | Software Due - Demos of your Software | - | 
 | N/A | Friday, April 9 2021  | -           | Bonus Assignment Due | - | 


### PR DESCRIPTION
Demos were scheduled for the first time this term. As such, my scheduling was a bit off.

This moves back Demo 3 from March 11 to March 25.

I think you should have the app launched sooner than the Demo 3 so this PR changes Demo 3 to talk more about the technical problems you are solving at that time.

Lastly, Demo 4 will be just to the teaching staff as it's your full software :)